### PR TITLE
Correct misplaced parentheses  # TokenError: EOF

### DIFF
--- a/containers/dispatcher/dispatch-jobs.py
+++ b/containers/dispatcher/dispatch-jobs.py
@@ -7,7 +7,7 @@ import time
 import os
 from fontprojects import git_repos
 
-local_devel = (os.environ.get("FONTBAKERY_LOCAL_DEVEL" == 1)
+local_devel = os.environ.get("FONTBAKERY_LOCAL_DEVEL") == 1
 local_families_selection = [
   "Roboto",
   "Roboto Condensed",


### PR DESCRIPTION
`TokenError: EOF in multi-line statement`

flake8 testing of https://github.com/googlefonts/fontbakery-dashboard on Python 2.7.13

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./containers/dispatcher/dispatch-jobs.py:11:25: E901 SyntaxError: invalid syntax
local_families_selection = [
                        ^

./containers/dispatcher/dispatch-jobs.py:66:1: E901 TokenError: EOF in multi-line statement
^
```