### PR TITLE
_BaseServer (backport): improved server structure

### DIFF
--- a/containers/base/javascript/bower.json
+++ b/containers/base/javascript/bower.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "requirejs": "~2.3.2",
     "marked": "~0.3.4",
-    "jiff": "~0.7.3"
+    "jiff": "~0.7.3",
+    "ansi_up": "https://github.com/drudru/ansi_up.git"
   }
 }

--- a/containers/base/javascript/browser/js/main.js
+++ b/containers/base/javascript/browser/js/main.js
@@ -109,7 +109,7 @@ define([
           , report = new Report(container, templatesContainer, data)
           ;
 
-        socket.on('changes', report.onChange.bind(report));
+        socket.on('changes-report', report.onChange.bind(report));
         socket.emit('subscribe-report', { id: data.id });
     }
 
@@ -134,7 +134,7 @@ define([
           , report = new CollectionReport(container, templatesContainer, data)
           ;
 
-        socket.on('changes', report.onChange.bind(report));
+        socket.on('changes-collection', report.onChange.bind(report));
         socket.emit('subscribe-collection', { id: data.id });
     }
 
@@ -144,7 +144,7 @@ define([
          , socket = socketio('/')
          , dashboard = new DashboardController(container, templatesContainer, data)
          ;
-        socket.on('changes', dashboard.onChange.bind(dashboard));
+        socket.on('changes-dashboard', dashboard.onChange.bind(dashboard));
         console.log('subscribe-dashboard');
         socket.emit('subscribe-dashboard', {});
     }

--- a/containers/base/javascript/node/_BaseServer.js
+++ b/containers/base/javascript/node/_BaseServer.js
@@ -1,0 +1,222 @@
+#! /usr/bin/env node
+"use strict";
+// this is expected to run in nodejs
+/* global require */
+/* jshint esnext:true */
+
+const express = require('express')
+  , http = require('http')
+  , socketio = require('socket.io')
+  , path = require('path')
+  , messages_pb = require('protocolbuffers/messages_pb')
+  , { IOOperations } = require('./util/IOOperations')
+  , { CacheClient }  = require('./util/CacheClient')
+  , { ReportsClient } = require('./util/ReportsClient')
+  , ROOT_PATH = __dirname.split(path.sep).slice(0, -1).join(path.sep)
+  ;
+
+
+/**
+ * Using a class here, so state variables are managed not on module level
+ * Initialization starts the server.
+ *
+ * NOTE: this is in a state of rewrite to better separate the concerns
+ * of providing resources and connection to the outside word versus the
+ * actual business logic implementation.
+ * The sub-apps and this are rather tightly coupled.
+ */
+function _BaseServer(logging, portNum, amqpSetup, dbSetup, cacheSetup
+                                , reportsSetup) {
+    //jshint validthis:true
+    this._log = logging;
+    this._portNum = portNum;
+    this._app = express();
+    this._httpServer = http.createServer(this._app);
+    this._sio = socketio(this._httpServer);
+
+    var serveStandardClient = this.fbIndex.bind(this);
+    Object.defineProperty(this, 'serveStandardClient', {
+        value: serveStandardClient
+    });
+
+    // dependency injection resources
+    //         name: [builder, initFunctionName]
+    this._DIResourceBuilders = new Map([
+        ['server', [()=>this, null]]
+      , ['log', [()=>this._log, null]]
+      , ['io', [
+                ()=>new IOOperations(this._log, dbSetup, amqpSetup)
+              , 'init'
+            ]
+        ]
+      , ['cache', [
+                ()=>new CacheClient(
+                                this._log
+                              , cacheSetup.host, cacheSetup.port
+                              , messages_pb, 'fontbakery.dashboard')
+              , 'waitForReady'
+            ]
+        ]
+      , ['reports', [()=>new ReportsClient(
+                                this._log, reportsSetup.host
+                              , reportsSetup.port)
+              , 'waitForReady'
+            ]
+        ]
+    ]);
+    this._DIResourcesCache = new Map();
+    this._DIResourcesCache.set('*app:/', this._app); // root express app
+    var promises;
+    [this._services, promises] = this._initServices();
+
+    // Start serving when the database and rabbitmq queue is ready
+    Promise.all(promises)
+    .then(this._listen.bind(this))
+    .catch(function(err) {
+        this._log.error('Can\'t initialize server.', err);
+        process.exit(1);
+    }.bind(this));
+
+    this._sio.on('connection', this._onSocketConnect.bind(this));
+}
+
+var _p = _BaseServer.prototype;
+
+_p._serviceDefinitions = [];
+
+_p._getServiceDependency = function(appLocation, name) {
+    var promise = null;
+    let key = name === '*app'
+                        ? [name, appLocation].join(':')
+                        : name
+                        ;
+    if(!this._DIResourcesCache.has(key)) {
+        if(name === '*app') {
+            // a special case
+            // name is e.g. : *app:/dispatcher
+            let subApp = express();
+            this._app.get(appLocation, subApp); // register with root app
+            this._DIResourcesCache.set(key, subApp);
+        }
+        else if (this._DIResourceBuilders.has(key)) {
+            let [builder, initFunc] = this._DIResourceBuilders.get(key)
+              , resource = builder.call(this)
+              ;
+            // initFinc is e.g. 'waitForReady' for gRPC clients
+            if(initFunc)
+                promise = resource[initFunc]();
+            this._DIResourcesCache.set(key, resource);
+        }
+        else
+            throw new Error('Don\'t know how to get resource named "'+name+'".');
+    }
+    return [this._DIResourcesCache.get(key), promise];
+};
+
+_p._initService = function(appLocation, Constructor, dependencies) {
+    var service
+      , promises = []
+      , args = []
+      ;
+    for(let name of dependencies) {
+        let [dependency, promise] = this._getServiceDependency(appLocation, name);
+        args.push(dependency);
+        if(promise)
+            promises.push(promise);
+    }
+    service = new Constructor(...args);
+    return [service, promises];
+};
+
+_p._initServices = function() {
+    var services = []
+      , promises = []
+      ;
+    for(let definition of this._serviceDefinitions) {
+        let [service, promises_] = this._initService(...definition);
+        services.push(service);
+        promises.push(...promises_);
+    }
+    return [services, promises];
+};
+
+_p._listen = function() {
+    this._httpServer.listen(this._portNum);
+    this._log.info('Listening to port', this._portNum);
+};
+
+_p.registerSocketListener = function(eventName, eventHandler, disconnectHandler){
+    this._socketListeners.push(eventName, eventHandler, disconnectHandler);
+};
+
+/**
+ * GET
+ *
+ * CLIENT
+ *  : say hello
+ *  : initiate the d'n'd interface to post fonts
+ *        on success
+ *        change url to docid url
+ *        init socketio connection for docid (with answer from post)
+ */
+_p.fbIndex = function(req, res, next) {
+    // jshint unused:vars
+    return res.sendFile('browser/html/client.html',
+                                                    {root: ROOT_PATH});
+};
+
+/**
+ * socketio connect
+  SERVER
+    : on connect
+        test if docid exists
+        create rethinkdb change feed for docid
+        store change feed and connection together
+    : on disconnect
+        (implicitly: close socket)
+        close changefeed
+    : on error???
+        close changefeed
+        close socket
+ *
+ * wrap in:
+ *
+ * this._sio.on('connection', this._onSocketConnect.bind(this));
+ *
+ */
+_p._socketOnSubscribe = function(socket, eventName, handler, data) {
+    this._log.info('_onSocketConnect: socket', socket.id ,'subscription '
+                                        + 'requested for', eventName, data);
+    if(typeof data.id !== 'string')
+        // this is actually required (historically)
+        // ??? why can't we fix this with an error?
+        // and at the position where data.id is actually needed/evaluated?
+        data.id = '';
+    handler.call(this, socket, data);
+};
+
+_p._socketOnDisconnect = function(socket, eventName, handler, reason) {
+    this._log.debug('socket:', socket.id
+                        , 'disconnecting from:', eventName
+                        , 'reason:', reason);
+    handler.call(this, socket);
+};
+
+
+_p._subscribeToSocketEvent = function(socket, eventName
+                                    , eventHandler, disconnectHandler) {
+    socket.on(eventName, data=>this._socketOnSubscribe(
+                socket, eventName, eventHandler, data));
+    if(disconnectHandler)
+        socket.on('disconnecting',reason=>this._socketOnDisconnect(
+                socket, eventName, disconnectHandler, reason));
+};
+
+_p._onSocketConnect = function(socket) {
+    // wait for docid request ...
+    // extracting [HEAD, ...TAIL] from the values of this._socketListeners
+    for(let [eventName, ...handlers] of this._socketListeners)
+        this._subscribeToSocketEvent(socket, eventName, ...handlers);
+};
+
+exports._BaseServer = _BaseServer;

--- a/containers/base/javascript/node/_BaseServer.js
+++ b/containers/base/javascript/node/_BaseServer.js
@@ -1,8 +1,6 @@
 #! /usr/bin/env node
 "use strict";
-// this is expected to run in nodejs
-/* global require */
-/* jshint esnext:true */
+/* jshint esnext:true, node:true */
 
 const express = require('express')
   , http = require('http')

--- a/containers/base/javascript/node/_BaseServer.js
+++ b/containers/base/javascript/node/_BaseServer.js
@@ -156,7 +156,7 @@ _p._listen = function() {
 };
 
 _p.registerSocketListener = function(eventName, eventHandler, disconnectHandler){
-    this._socketListeners.push(eventName, eventHandler, disconnectHandler);
+    this._socketListeners.push([eventName, eventHandler, disconnectHandler]);
 };
 
 /**

--- a/containers/base/javascript/node/_BaseServer.js
+++ b/containers/base/javascript/node/_BaseServer.js
@@ -194,15 +194,16 @@ _p.fbIndex = function(req, res, next) {
  * this._sio.on('connection', this._onSocketConnect.bind(this));
  *
  */
-_p._socketOnSubscribe = function(socket, eventName, handler, data) {
+_p._socketOnSubscribe = function(socket, eventName, handler, ...data_callback) {
+    var [data, ...moredata_callback] = data_callback;
     this._log.info('_onSocketConnect: socket', socket.id ,'subscription '
-                                        + 'requested for', eventName, data);
+                                        + 'requested for', eventName, data, ...moredata_callback);
     if(typeof data.id !== 'string')
         // this is actually required (historically)
         // ??? why can't we fix this with an error?
         // and at the position where data.id is actually needed/evaluated?
         data.id = '';
-    handler.call(this, socket, data);
+    handler.call(this, socket, data, ...moredata_callback);
 };
 
 _p._socketOnDisconnect = function(socket, reason) {
@@ -218,8 +219,8 @@ _p._socketOnDisconnect = function(socket, reason) {
 
 
 _p._subscribeToSocketEvent = function(socket, eventName, eventHandler) {
-    socket.on(eventName, data=>this._socketOnSubscribe(
-                socket, eventName, eventHandler, data));
+    socket.on(eventName, (...data_callback)=>this._socketOnSubscribe(
+                socket, eventName, eventHandler, ...data_callback));
 };
 
 _p._onSocketConnect = function(socket) {

--- a/containers/base/javascript/node/api.js
+++ b/containers/base/javascript/node/api.js
@@ -7,11 +7,10 @@
 const path = require('path')
   , fs = require('fs')
   , bodyParser = require('body-parser')
-  , messages_pb = require('protocolbuffers/messages_pb')
 
   , marked = require('marked')
 
-  , { ReportsQuery, ReportIds } = messages_pb
+  , { ReportsQuery, ReportIds, Files } = require('protocolbuffers/messages_pb')
   , { Timestamp } = require('google-protobuf/google/protobuf/timestamp_pb.js')
 
   , { getSetup } = require('./util/getSetup')
@@ -353,12 +352,12 @@ _p.fbCollectionReport = function(req, res, next) {
 };
 
 _p._getFilesMessage = function(buffer) {
-    var filesMessage = messages_pb.Files.deserializeBinary(
+    var filesMessage = Files.deserializeBinary(
                                                 new Uint8Array(buffer))
         // reconstruct the filesMessage to have all files sorted by name
         // and to discard duplicates (which is possible with this message
         // format
-      , newMessage = new messages_pb.Files()
+      , newMessage = new Files()
       , i, l, file, seen = new Set()
       , files = filesMessage.getFilesList()
       , newFilesList = []

--- a/containers/base/javascript/node/api.js
+++ b/containers/base/javascript/node/api.js
@@ -539,7 +539,7 @@ _p.fbSocketConnect = function(socket) {
  *      close changefeed
  */
 _p._updateFamilytestReport = function(cursor, socket, data) {
-    var channel = 'changes';
+    var channel = 'changes-report';
     socket.emit(channel, data);
     // This is a simple familytest subscription, we don't organize these
     // to talk to multiple sockets yet. Even if we did, the reason for
@@ -871,7 +871,7 @@ _p._primeCollectionSubscription = function(collectionId) {
 _p._sendCollectionDocChange = function(collectionId, family_name) {
     var collectionSubscription = this._collectionSubscriptions.get(collectionId)
       , doc = collectionSubscription.documents.get(family_name)
-      , channel = 'changes'
+      , channel = 'changes-collection'
       ;
     collectionSubscription.consumers.forEach(socketId => {
         let consumer = this._collectionConsumers.get(socketId);
@@ -882,7 +882,7 @@ _p._sendCollectionDocChange = function(collectionId, family_name) {
 _p._sendInitialCollectionSubscription = function(collectionId, socketId) {
     var collectionSubscription = this._collectionSubscriptions.get(collectionId)
       , consumer = this._collectionConsumers.get(socketId)
-      , channel = 'changes'
+      , channel = 'changes-collection'
       ;
     // if there is any data, it is ready to emit!
     for(let [/*family_name*/, doc] of collectionSubscription.documents)
@@ -1067,7 +1067,7 @@ _p._updateDashboardCollectionDoc = function(isPriming, doc) {
 };
 
 _p._sendToDashboardConsumer = function(consumer, collectiontest_data) {
-    var channel = 'changes'
+    var channel = 'changes-dashboard'
       , familytests_id = collectiontest_data.familytests_id
       ;
 

--- a/containers/base/javascript/node/api.js
+++ b/containers/base/javascript/node/api.js
@@ -5,8 +5,6 @@
 /* jshint esnext:true */
 
 const express = require('express')
-  , http = require('http')
-  , socketio = require('socket.io')
   , path = require('path')
   , fs = require('fs')
   , bodyParser = require('body-parser')
@@ -18,223 +16,9 @@ const express = require('express')
   , { Timestamp } = require('google-protobuf/google/protobuf/timestamp_pb.js')
 
   , { getSetup } = require('./util/getSetup')
-  , { IOOperations } = require('./util/IOOperations')
-  , { CacheClient }  = require('./util/CacheClient')
-  , { ReportsClient } = require('./util/ReportsClient')
   , ROOT_PATH = __dirname.split(path.sep).slice(0, -1).join(path.sep)
+  , { _BaseServer } = require('./_BaseServer')
   ;
-
-
-/**
- * Using a class here, so state variables are managed not on module level
- * Initialization starts the server.
- *
- * NOTE: this is in a state of rewrite to better separate the concerns
- * of providing resources and connection to the outside word versus the
- * actual business logic implementation.
- * The sub-apps and this are rather tightly coupled.
- */
-
-const Server = (function() {
-
-function Server(logging, portNum,  amqpSetup, dbSetup, cacheSetup
-                                                     , reportsSetup) {
-    this._log = logging;
-    this._portNum = portNum;
-    this._app = express();
-    this._sio = socketio(this._server);
-    this._server = http.createServer(this._app);
-
-    var serveStandardClient = this.fbIndex.bind(this);
-    Object.defineProperty(this, 'serveStandardClient', {
-        value: serveStandardClient
-    });
-
-    // dependency injection resources
-    //         name: [builder, initFunctionName]
-    this._DIResourceBuilders = new Map([
-        ['server', [()=>this, null]]
-      , ['log', [()=>this._log, null]]
-      , ['io', [
-                ()=>new IOOperations(this._log, dbSetup, amqpSetup)
-              , 'init'
-            ]
-        ]
-      , ['cache', [
-                ()=>new CacheClient(
-                                this._log
-                              , cacheSetup.host, cacheSetup.port
-                              , messages_pb, 'fontbakery.dashboard')
-              , 'waitForReady'
-            ]
-        ]
-      , ['reports', [()=>new ReportsClient(
-                                this._log, reportsSetup.host
-                              , reportsSetup.port)
-              , 'waitForReady'
-            ]
-        ]
-    ]);
-    this._DIResourcesCache = new Map();
-    this._DIResourcesCache.set('*app:/', this._app); // root express app
-    var promises;
-    [this._services, promises] = this._initServices();
-
-    // Start serving when the database and rabbitmq queue is ready
-    Promise.all(promises)
-    .then(this._listen.bind(this))
-    .catch(function(err) {
-        this._log.error('Can\'t initialize server.', err);
-        process.exit(1);
-    }.bind(this));
-
-    this._sio.on('connection', this._onSocketConnect.bind(this));
-    this._server = http.createServer(this._app);
-}
-
-var _p = Server.prototype;
-
-_p._serviceDefinitions = [];
-
-_p._getServiceDependency = function(appLocation, name) {
-    var promise = null;
-    let key = name === '*app'
-                        ? [name, appLocation].join(':')
-                        : name
-                        ;
-    if(!this._DIResourcesCache.has(key)) {
-        if(name === '*app') {
-            // a special case
-            // name is e.g. : *app:/dispatcher
-            let subApp = express();
-            this._app.get(appLocation, subApp); // register with root app
-            this._DIResourcesCache.set(key, subApp);
-        }
-        else if (this._DIResourceBuilders.has(key)) {
-            let [builder, initFunc] = this._DIResourceBuilders.get(key)
-              , resource = builder.call(this)
-              ;
-            // initFinc is e.g. 'waitForReady' for gRPC clients
-            if(initFunc)
-                promise = resource[initFunc]();
-            this._DIResourcesCache.set(key, resource);
-        }
-        else
-            throw new Error('Don\'t know how to get resource named "'+name+'".');
-    }
-    return [this._DIResourcesCache.get(key), promise];
-};
-
-_p._initService = function(appLocation, Constructor, dependencies) {
-    var service
-      , promises = []
-      , args = []
-      ;
-    for(let name of dependencies) {
-        let [dependency, promise] = this._getServiceDependency(appLocation, name);
-        args.push(dependency);
-        if(promise)
-            promises.push(promise);
-    }
-    service = new Constructor(...args);
-    return [service, promises];
-};
-
-_p._initServices = function() {
-    var services = []
-      , promises = []
-      ;
-    for(let definition of this._serviceDefinitions) {
-        let [service, promises_] = this._initService(...definition);
-        services.push(service);
-        promises.push(...promises_);
-    }
-    return [services, promises];
-};
-
-_p._listen = function() {
-    this._server.listen(this._portNum);
-    this._log.info('Listening to port', this._portNum);
-};
-
-_p.registerSocketListener = function(eventName, eventHandler, disconnectHandler){
-    this._socketListeners.push(eventName, eventHandler, disconnectHandler);
-};
-
-/**
- * GET
- *
- * CLIENT
- *  : say hello
- *  : initiate the d'n'd interface to post fonts
- *        on success
- *        change url to docid url
- *        init socketio connection for docid (with answer from post)
- */
-_p.fbIndex = function(req, res, next) {
-    // jshint unused:vars
-    return res.sendFile('browser/html/client.html',
-                                                    {root: ROOT_PATH});
-};
-
-/**
- * socketio connect
-  SERVER
-    : on connect
-        test if docid exists
-        create rethinkdb change feed for docid
-        store change feed and connection together
-    : on disconnect
-        (implicitly: close socket)
-        close changefeed
-    : on error???
-        close changefeed
-        close socket
- *
- * wrap in:
- *
- * this._sio.on('connection', this._onSocketConnect.bind(this));
- *
- */
-_p._socketOnSubscribe = function(socket, eventName, handler, data) {
-    this._log.info('_onSocketConnect: socket', socket.id ,'subscription '
-                                        + 'requested for', eventName, data);
-    if(typeof data.id !== 'string')
-        // this is actually required (historically)
-        // ??? why can't we fix this with an error?
-        // and at the position where data.id is actually needed/evaluated?
-        data.id = '';
-    handler.call(this, socket, data);
-};
-
-_p._socketOnDisconnect = function(socket, eventName, handler, reason) {
-    this._log.debug('socket:', socket.id
-                        , 'disconnecting from:', eventName
-                        , 'reason:', reason);
-    handler.call(this, socket);
-};
-
-
-_p._subscribeToSocketEvent = function(socket, eventName
-                                    , eventHandler, disconnectHandler) {
-    socket.on(eventName, data=>this._socketOnSubscribe(
-                socket, eventName, eventHandler, data));
-    if(disconnectHandler)
-        socket.on('disconnecting',reason=>this._socketOnDisconnect(
-                socket, eventName, disconnectHandler, reason));
-};
-
-_p._onSocketConnect = function(socket) {
-    // wait for docid request ...
-    // extracting [HEAD, ...TAIL] from the values of this._socketListeners
-    for(let [eventName, ...handlers] of this._socketListeners)
-        this._subscribeToSocketEvent(socket, eventName, ...handlers);
-};
-
-
-return Server;
-})();
-
 
 const FontBakeryServer = (function(){
 
@@ -242,10 +26,10 @@ function FontBakeryServer(...args) {
     this._serviceDefinitions = [
         ['/', DashboardAPIService, ['server', '*app', 'log', 'io', 'cache', 'reports']]
     ];
-    Server.call(this, ...args);
+    _BaseServer.call(this, ...args);
 }
 
-_p = FontBakeryServer.prototype = Object.create(Server.prototype);
+_p = FontBakeryServer.prototype = Object.create(_BaseServer.prototype);
 
 return FontBakeryServer;
 
@@ -1314,6 +1098,6 @@ if (typeof require != 'undefined' && require.main==module) {
     setup.logging.log('Loglevel', setup.logging.loglevel);
     // storing in global scope, to make it available for inspection
     // in the debugger.
-    global.server = new Server(setup.logging, 3000, setup.amqp, setup.db
+    global.server = new FontBakeryServer(setup.logging, 3000, setup.amqp, setup.db
             , setup.cache, setup.reports);
 }

--- a/containers/base/javascript/node/api.js
+++ b/containers/base/javascript/node/api.js
@@ -1154,7 +1154,6 @@ if (typeof require != 'undefined' && require.main==module) {
     var setup = getSetup();
     setup.logging.info('Init server ...');
     setup.logging.log('Loglevel', setup.logging.loglevel);
-    setup.logging.debug('Loglevel', setup.logging.loglevel);
     // storing in global scope, to make it available for inspection
     // in the debugger.
     global.server = new Server(setup.logging, 3000, setup.amqp, setup.db

--- a/containers/base/javascript/node/api.js
+++ b/containers/base/javascript/node/api.js
@@ -103,13 +103,13 @@ function DashboardAPIService(server, app, logging,  io, cache, reports) {
     this._app.get('/status-report/:id', this.fbStatusReport.bind(this));
 
     this.registerSocketListener('subscribe-report'
-            , _p._subscribeToFamilytestReport/* , no unsubscribe! */);
+            , this._subscribeToFamilytestReport.bind(this)/* , no disconnect! */);
     this.registerSocketListener('subscribe-collection'
             , this._subscribeToCollectionReport.bind(this)
-            , this._unsubscribeFromCollections.bind(this));
+            , this._disconectFromCollections.bind(this));
     this.registerSocketListener('subscribe-dashboard'
             , this._subscribeToDashboard.bind(this)
-            , this._unsubscribeFromDashboard.bind(this));
+            , this._disconnectFromDashboard.bind(this));
 
 
 }
@@ -866,7 +866,7 @@ _p._makeCollectionConsumer = function(socket) {
  *              and then delete it
  *      and then delete it
  */
-_p._unsubscribeFromCollections = function(socket) {
+_p._disconectFromCollections = function(socket) {
     var socketId = socket.id
       , consumer = this._collectionConsumers.get(socketId)
       ;
@@ -964,7 +964,7 @@ _p._subscribeToCollectionReport = function(socket, data) {
     this._sendInitialCollectionSubscription(collectionId, socket.id);
 };
 
-_p._unsubscribeFromDashboard = function(socket) {
+_p._disconnectFromDashboard = function(socket) {
     var socketId = socket.id
       , consumers, consumer;
 
@@ -1068,7 +1068,7 @@ _p._subscribeToDashboard = function(socket, data) {
     if(consumer) {
         // is already subscribed ... ?
         // reset the consumer: unsbscribe all
-        // also this is what we to do on a hang up, see _unsubscribeFromDashboard
+        // also this is what we to do on a hang up, see _disconnectFromDashboard
         consumer.unsubscribe_callbacks.forEach(unsubscribe => unsubscribe());
         consumer.unsubscribe_callbacks = new Map();
     }

--- a/containers/base/javascript/node/api.js
+++ b/containers/base/javascript/node/api.js
@@ -102,12 +102,12 @@ function DashboardAPIService(server, app, logging,  io, cache, reports) {
     // status report document (client renders into html for now);
     this._app.get('/status-report/:id', this.fbStatusReport.bind(this));
 
-    this.registerSocketListener('subscribe-report'
+    this._server.registerSocketListener('subscribe-report'
             , this._subscribeToFamilytestReport.bind(this)/* , no disconnect! */);
-    this.registerSocketListener('subscribe-collection'
+    this._server.registerSocketListener('subscribe-collection'
             , this._subscribeToCollectionReport.bind(this)
             , this._disconectFromCollections.bind(this));
-    this.registerSocketListener('subscribe-dashboard'
+    this._server.registerSocketListener('subscribe-dashboard'
             , this._subscribeToDashboard.bind(this)
             , this._disconnectFromDashboard.bind(this));
 

--- a/docs/DEPLOYLOG.md
+++ b/docs/DEPLOYLOG.md
@@ -494,3 +494,13 @@ Thus we can say a pod to only attach to that pool with:
       nodeSelector:
         cloud.google.com/gke-nodepool: checker-pool-1
 ```
+
+
+## rethink reboot See #78
+
+```
+kubectl delete deployment rethinkdb-admin rethinkdb-proxy rethinkdb-replica-1 rethinkdb-replica-2 rethinkdb-replica-3  rethinkdb-replica-4
+kubectl apply -f kubernetes/gcloud-rethinkdb-stage-1.yaml
+kubectl apply -f kubernetes/gcloud-rethinkdb-proxy.yaml
+kubectl apply -f kubernetes/gcloud-rethinkdb-stage-2.yaml
+```


### PR DESCRIPTION
There have been several changes of the server architecture in the branch `release-pipeline` (#76). No I'm intermediately tasked tasked to tackle #86. I don't want to build that onto current master and then later have porting issues. The best way is to backport the changes from `release-pipeline` which I made here with some serious git history manipulation. The main files of this PR are `javascript/node/api.js` and `javascript/api/_BaseServer.js`.