### PR TITLE
This is a maintenance PR

### DIFF
--- a/containers/base/javascript/Dockerfile
+++ b/containers/base/javascript/Dockerfile
@@ -1,12 +1,20 @@
 # that's Debian Stretch (current stable: Debian 9)
 # and node 11.15.0; currently nodegit doesnt build with node 12.x
-FROM node:11.15.0-stretch
+FROM node:12.13.0-buster
 
 
 RUN touch /tmp/cache_spoof_13
 
-RUN npm install -g bower browserify requirejs;
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y software-properties-common
 
+# mentioned in https://github.com/nodegit/nodegit
+RUN apt-get update \
+    && apt-get install -y libssl-dev libpcre2-posix0 libkrb5-3 \
+    libk5crypto3 libcom-err2 libpcre2-dev libkrb5-dev
+
+
+RUN npm install -g bower browserify requirejs;
 
 ADD ./.bowerrc ./bower.json ./package.json /var/javascript/
 
@@ -14,17 +22,16 @@ RUN touch /tmp/cache_spoof_2
 ADD ./generated_modules /var/javascript/generated_modules
 
 RUN touch /tmp/cache_spoof_1
+
 # will also invoke bower install etc.
 # --production: don't install dev-dependencies
 RUN cd /var/javascript && npm install --unsafe-perm --production
 
 
-# It seems to be moost roust to read our METADATA.pb files using python
+# It seems to be most robust to read our METADATA.pb files using python
 # that's the only reason for this dependency, used in manifestSources
 # via the module /node/util/getMetadataPb
-RUN apt-get update && apt-get upgrade -y \
-    && apt-get install -y software-properties-common \
-    && apt-get update \
+RUN apt-get update \
     && apt-get install -y python-dev git;
 RUN curl -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py; python /tmp/get-pip.py;
 RUN pip install --upgrade pip

--- a/containers/base/javascript/Dockerfile
+++ b/containers/base/javascript/Dockerfile
@@ -56,7 +56,15 @@ RUN mkdir -p /var/javascript/browser/js/bower_components/ansi_up/ \
     && curl -o /var/javascript/browser/js/bower_components/ansi_up/ansi_up.js \
                https://raw.githubusercontent.com/drudru/ansi_up/master/ansi_up.js
 
-ADD ./fontsgit /var/fontsgit
+# In the minikube development version it can be interesting to preload
+# the image with a current version of the github google/fonts repository.
+# If so in this directory (containers/base/javascript) do:
+# $ git clone --bare https://github.com/google/fonts.git fontsgit
+# Otherwise, if image file size is an issue:
+# $ mkdir fontsgit
+# Would be nice to have the ADD optional ...
+ADD ./fontsgit /var/git-repositories/github.com_google_fonts.git
+
 # This way we only need to rebuild the last intermediate container when
 # code changed, especially the npm install can be skipped!
 ADD ./browser /var/javascript/browser

--- a/containers/base/javascript/node/GitHubOperationsServer.js
+++ b/containers/base/javascript/node/GitHubOperationsServer.js
@@ -1225,7 +1225,7 @@ module.exports.GitHubOperationsServer = GitHubOperationsServer;
 
 if (typeof require != 'undefined' && require.main==module) {
     var { getSetup } = require('./util/getSetup')
-      , repoPath = './fontsgit'
+      , repoPath = '/var/git-repositories/github.com_google_fonts.git'
       , setup = getSetup(), gitHubOperationsServer, port=50051
         // all PRs are based on the respective upstream repository branch
       , remoteRefs = {

--- a/containers/base/javascript/node/manifestSources/CSVSpreadsheet.js
+++ b/containers/base/javascript/node/manifestSources/CSVSpreadsheet.js
@@ -1174,7 +1174,9 @@ _p.getSourceDetails = function(familyName) {
 if (typeof require != 'undefined' && require.main==module) {
     var setup = getSetup(), sources = [], server
       , familyWhitelist = setup.develFamilyWhitelist
-      , repoPath = './git-repositories'
+        // For development may contain /var/git-repositories/github.com_google_fonts.git
+        // /var/git-repositories$ git clone --bare https://github.com/google/fonts.git github.com_google_fonts.git
+      , repoPath = '/var/git-repositories'
       // TODO: could be configured via setup, however, not doing this
       // now, because the current situation doesn't require this.
       // This is the production data:

--- a/containers/base/javascript/node/manifestSources/Git.js
+++ b/containers/base/javascript/node/manifestSources/Git.js
@@ -1032,7 +1032,7 @@ if (typeof require != 'undefined' && require.main==module) {
 
     var setup = getSetup(), sources = [], server
        , familyWhitelist = setup.develFamilyWhitelist
-       , repoPath = './var/fontsgit'
+       , repoPath = '/var/git-repositories/github.com_google_fonts.git'
        , familyWhitelist = null
        , grpcPort=50051
        ;

--- a/containers/base/javascript/package.json
+++ b/containers/base/javascript/package.json
@@ -16,7 +16,7 @@
   "author": "Lasse Fister <commander@graphicore.de>",
   "license": "Apache-2.0",
   "dependencies": {
-    "amqplib": "^0.5.2",
+    "amqplib": "^0.5.5",
     "body-parser": "^1.19.0",
     "cookie-parser": "^1.4.3",
     "csv-parse": "^4.6.5",
@@ -25,7 +25,7 @@
     "grpc": "^1.21.1",
     "marked": "^0.7.0",
     "mime": "^2.4.4",
-    "nodegit": "^0.24.3",
+    "nodegit": "^0.26.2",
     "rethinkdbdash": "^2.3.31",
     "socket.io": "^2.2.0",
     "tmp": "0.0.33",

--- a/containers/base/python/Dockerfile
+++ b/containers/base/python/Dockerfile
@@ -1,7 +1,7 @@
-# disco == 19.04 LTS
-FROM ubuntu:disco
+# eoan == 19.08 NOT LTS  End of Life: July, 2020
+FROM ubuntu:eoan
 
-RUN touch /tmp/cache_spoof_18
+RUN touch /tmp/cache_spoof_1
 
 
 # START TZCONFIG FIX suggested in:
@@ -66,7 +66,7 @@ RUN pip3 install lxml; # ==3.5.0
 ADD requirements.txt /var/python/requirements.txt
 RUN pip3 install -r /var/python/requirements.txt
 
-RUN touch /tmp/cache_spoof_20
+RUN touch /tmp/cache_spoof_1
 
 # FIXME: doesn't install all dependencies!
 # RUN pip3 install git+https://github.com/graphicore/fontbakery@dashboard_related
@@ -81,7 +81,7 @@ RUN pip3 install fontbakery;
 # tools used for live debugging and profiling
 # RUN pip3 install memory-profiler
 # RUN apt-get install -y vim tmux htop
-# RUN touch /tmp/cache_spoof_16
+# RUN touch /tmp/cache_spoof_1
 # RUN pip3 install remote-pdb
 # RUN git clone --depth 1 -b fb_dashboard_bughunt_issue100_OOM https://github.com/graphicore/fontdiffenator.git /var/fontdiffenator;\
 #     pip3 install -e /var/fontdiffenator;
@@ -89,7 +89,7 @@ RUN pip3 install fontdiffenator;
 
 RUN pip3 install gfdiffbrowsers
 
-RUN touch /tmp/cache_spoof_2
+RUN touch /tmp/cache_spoof_1
 
 # in update_protobufs.sh the command `python -m grpc_tools.protoc`
 # doesn't create python 3 ready relative imports

--- a/containers/rethinkdb/Dockerfile
+++ b/containers/rethinkdb/Dockerfile
@@ -2,21 +2,21 @@
 # is based on Debian 8 Jessie, while Debian 9 Stretch is current.
 # And the project doesn't support a stretch deb image :-/
 # Then it mixes in a simplified yet inspired approach of rosskukulinski/rethinkdb-kubernetes
-FROM debian:stretch
+FROM debian:buster
 
 RUN apt-get update && apt-get upgrade -y \
     && apt-get install  -y procps sudo mg git \
     build-essential protobuf-compiler python \
     libprotobuf-dev libcurl4-openssl-dev libboost-all-dev \
-    libncurses5-dev libjemalloc-dev wget m4 clang libssl1.0-dev \
+    libncurses5-dev libjemalloc-dev wget m4 clang libssl-dev \
     && rm -rf /var/lib/apt/lists/*;
 
 
 RUN mkdir -p /tmp/build \
     && cd /tmp/build \
-    && wget https://download.rethinkdb.com/dist/rethinkdb-2.3.6.tgz \
-    && tar xf rethinkdb-2.3.6.tgz \
-    && cd rethinkdb-2.3.6 \
+    && wget https://download.rethinkdb.com/dist/rethinkdb-2.3.7.tgz \
+    && tar xf rethinkdb-2.3.7.tgz \
+    && cd rethinkdb-2.3.7 \
     && ./configure --allow-fetch CXX=clang++ \
     && make -j8 \
     && make install \

--- a/docs/DEPLOYLOG.md
+++ b/docs/DEPLOYLOG.md
@@ -618,6 +618,7 @@ $ docker push gcr.io/fontbakery-168509/base-javascript:3
 # downtime then ...
 $ ~/fontbakery-dashboard> kubectl delete deployment fontbakery-storage-persistence
 # this excludes rabbitmq and rethinkdb
+$ ~/fontbakery-dashboard> ./set-gcloud-vars
 $ ~/fontbakery-dashboard> find ./kubernetes -type f -name 'gcloud-fontbakery-*' -exec kubectl apply -f {} ';'
 
 ```

--- a/kubernetes/minikube-fontbakery-api.yaml
+++ b/kubernetes/minikube-fontbakery-api.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1 # for versions before 1.6.0 use extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fontbakery-api
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      run: fontbakery-api
   template:
     metadata:
       labels:

--- a/kubernetes/minikube-fontbakery-dispatcher.yaml
+++ b/kubernetes/minikube-fontbakery-dispatcher.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1 # for versions before 1.6.0 use extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fontbakery-dispatcher
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: fontbakery-dispatcher
   template:
     metadata:
       labels:

--- a/kubernetes/minikube-fontbakery-github-auth.yaml
+++ b/kubernetes/minikube-fontbakery-github-auth.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1 # for versions before 1.6.0 use extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fontbakery-github-auth
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: fontbakery-github-auth
   template:
     metadata:
       labels:

--- a/kubernetes/minikube-fontbakery-github-operations.yaml
+++ b/kubernetes/minikube-fontbakery-github-operations.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1 # for versions before 1.6.0 use extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fontbakery-github-operations
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: fontbakery-github-operations
   template:
     metadata:
       labels:

--- a/kubernetes/minikube-fontbakery-init-workers.yaml
+++ b/kubernetes/minikube-fontbakery-init-workers.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1 # for versions before 1.6.0 use extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fontbakery-init-workers
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: fontbakery-init-workers
   template:
     metadata:
       labels:

--- a/kubernetes/minikube-fontbakery-manifest-csvupstream.yaml
+++ b/kubernetes/minikube-fontbakery-manifest-csvupstream.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1 # for versions before 1.6.0 use extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fontbakery-manifest-csvupstream
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: fontbakery-manifest-csvupstream
   template:
     metadata:
       labels:

--- a/kubernetes/minikube-fontbakery-manifest-gfapi.yaml
+++ b/kubernetes/minikube-fontbakery-manifest-gfapi.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1 # for versions before 1.6.0 use extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fontbakery-manifest-gfapi
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: fontbakery-manifest-gfapi
   template:
     metadata:
       labels:

--- a/kubernetes/minikube-fontbakery-manifest-githubgf.yaml
+++ b/kubernetes/minikube-fontbakery-manifest-githubgf.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1 # for versions before 1.6.0 use extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fontbakery-manifest-githubgf
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: fontbakery-manifest-githubgf
   template:
     metadata:
       labels:

--- a/kubernetes/minikube-fontbakery-manifest-master.yaml
+++ b/kubernetes/minikube-fontbakery-manifest-master.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1 # for versions before 1.6.0 use extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fontbakery-manifest-master
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: fontbakery-manifest-master
   template:
     metadata:
       labels:

--- a/kubernetes/minikube-fontbakery-reports.yaml
+++ b/kubernetes/minikube-fontbakery-reports.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1 # for versions before 1.6.0 use extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fontbakery-reports
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: fontbakery-reports
   template:
     metadata:
       labels:

--- a/kubernetes/minikube-fontbakery-storage-cache.yaml
+++ b/kubernetes/minikube-fontbakery-storage-cache.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1 # for versions before 1.6.0 use extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fontbakery-storage-cache
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: fontbakery-storage-cache
   template:
     metadata:
       labels:

--- a/kubernetes/minikube-fontbakery-storage-persistence.yaml
+++ b/kubernetes/minikube-fontbakery-storage-persistence.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1 # for versions before 1.6.0 use extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fontbakery-storage-persistence
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: fontbakery-storage-persistence
   template:
     metadata:
       labels:

--- a/kubernetes/minikube-fontbakery-worker.yaml
+++ b/kubernetes/minikube-fontbakery-worker.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fontbakery-worker
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      run: fontbakery-worker
   template:
     metadata:
       labels:

--- a/kubernetes/minikube-rabbitmq.yaml
+++ b/kubernetes/minikube-rabbitmq.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -6,6 +6,9 @@ metadata:
   name: rabbitmq
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: rabbitmq
   template:
     metadata:
       labels:

--- a/kubernetes/minikube-rethinkdb.yaml
+++ b/kubernetes/minikube-rethinkdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -6,6 +6,9 @@ metadata:
   name: rethinkdb-replica-1
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      db: rethinkdb
   template:
     metadata:
       labels:


### PR DESCRIPTION
* Upgrade to work with current versions of minikube (v1.5.2) with kubernetes (v1.16.2).
* Update Dockerfiles to use more current base images.
* Repair and unify a mechanism that preloads the Javascript Docker-image with the google/fonts repo for faster initiation if some pots in minikube/development environments.